### PR TITLE
Bump peer dependency range of react

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "typescript": "4.8.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": ">16.0.0 <19"
   },
   "peerDependenciesMeta": {
     "react": {


### PR DESCRIPTION
Same issue as in the citizen repo. This library works alongside newer versions of react. Yarn throws warnings if a newer version of React is installed along with this library because the newer React is outside the peer dependency range for this library, which is unnecessarily strict.